### PR TITLE
polymer removed and optimizations

### DIFF
--- a/elements/tei-render/package.json
+++ b/elements/tei-render/package.json
@@ -25,16 +25,12 @@
     "storybook:build": "build-storybook"
   },
   "dependencies": {
-    "@lrnwebcomponents/anchor-behaviors": "^2.6.16",
-    "@lrnwebcomponents/simple-toast": "^2.6.17",
-    "@lrnwebcomponents/simple-tooltip": "^2.6.17",
-    "@lrnwebcomponents/simple-modal": "^2.6.18",
-    "@lrnwebcomponents/simple-popover": "^2.6.17",
-    "@polymer/paper-icon-button": "^3.0.2",
-    "@polymer/iron-icons": "^3.0.1",
-    "@polymer/paper-toast": "^3.0.1",
-    "lit-element": "^2.3.1",
-    "lit-html": "^1.2.1"
+    "@lrnwebcomponents/anchor-behaviors": "^3.0.5",
+    "@lrnwebcomponents/simple-toast": "^3.0.6",
+    "@lrnwebcomponents/simple-modal": "^3.0.6",
+    "@lrnwebcomponents/simple-popover": "^3.0.6",
+    "@lrnwebcomponents/simple-icon": "^3.0.6",
+    "lit-element": "2.5.1"
   },
   "devDependencies": {
     "@open-wc/demoing-storybook": "^1.0.1",

--- a/elements/tei-render/src/TeiRender.js
+++ b/elements/tei-render/src/TeiRender.js
@@ -1,13 +1,7 @@
-import { LitElement, html } from "lit-element/lit-element.js";
+import { LitElement } from "lit-element/lit-element.js";
 import { CETEI } from './lib/ceteicean.js';
-import "@polymer/iron-icons/iron-icons.js";
-import "@polymer/paper-icon-button/paper-icon-button.js";
 import "@lrnwebcomponents/anchor-behaviors/anchor-behaviors.js";
-import "@lrnwebcomponents/simple-toast/simple-toast.js";
-import "@lrnwebcomponents/simple-tooltip/simple-tooltip.js";
 import "./lib/tei-note.js";
-import { setPassiveTouchGestures } from "@polymer/polymer/lib/utils/settings.js";
-
 const validModes = () => {
   return {
     drama: "Drama",
@@ -20,7 +14,6 @@ export class TeiRender extends LitElement {
    */
   constructor() {
     super();
-    setPassiveTouchGestures(true);
     // tee up the initial constructor
     this.CETEIcean = new CETEI();
     this.src = null;
@@ -41,7 +34,7 @@ export class TeiRender extends LitElement {
     this.lineStart = 1;
     this.pageIcon = "description";
     this.pageLabel = "See the original page";
-    window.SimpleToast.requestAvailability();
+    import("@lrnwebcomponents/simple-icon/lib/simple-icon-button-lite.js");
   }
   /**
    * LitElement / popular convention
@@ -189,7 +182,7 @@ export class TeiRender extends LitElement {
           "pb": function (elt) {
             // elt.innerHTML = elt.parentNode.lastChild.textContent;
             // elt.parentNode.lastChild.textContent = '';
-            let pbutton = document.createElement('paper-icon-button');
+            let pbutton = document.createElement('simple-icon-button-lite');
             pbutton.setAttribute('icon',"description");
             pbutton.setAttribute('label',this.pageLabel);
             let pblinked = document.createElement('a');
@@ -219,7 +212,7 @@ export class TeiRender extends LitElement {
           // set the line ID
           let currentLineNumber=i+1
           let lineId = `${lineIdPrefix}-${currentLineNumber}`, 
-            button = document.createElement('paper-icon-button');
+            button = document.createElement('simple-icon-button-lite');
           line.setAttribute('id',lineId);
           // set the line margin identifier for nth Line
           if( currentLineNumber % this.lineDisplay === 0 || currentLineNumber === 1 ){
@@ -233,17 +226,10 @@ export class TeiRender extends LitElement {
           // line.append(button);
           line.prepend(button);
         });
-        // let tbutton = document.createElement('paper-icon-button');
+        // let tbutton = document.createElement('simple-icon-button-lite');
         //   tbutton.setAttribute('icon',this.closeIcon);
         //   tbutton.setAttribute('label',this.closeLabel);
         //   tbutton.addEventListener('click', this.closeCopyLink);
-        // this.toast = document.createElement('paper-toast');
-        // this.toast.id ="relative-heading-toast";
-        // this.toast.duration = 5000;
-        // this.toast.appendChild(tbutton);
-        // this.appendChild(this.toast);
-        // console.log('toasty!',this.toast);
-
       });
     } catch (error) {
       console.log("Error in getting the document.")
@@ -317,27 +303,17 @@ export class TeiRender extends LitElement {
     el.select();
     document.execCommand("copy");
     document.body.removeChild(el);
-    
-    const evt = new CustomEvent("simple-toast-show", {
-      bubbles: true,
-      composed: true,
-      cancelable: true,
-      detail: {
-        text: `Copied link ${this.currentLineId} to your clipboard`,
-        duration: 3000
-      }
+    import("@lrnwebcomponents/simple-toast/simple-toast.js").then(() => {
+      this.dispatchEvent(new CustomEvent("simple-toast-show", {
+        bubbles: true,
+        composed: true,
+        cancelable: true,
+        detail: {
+          text: `Copied link ${this.currentLineId} to your clipboard`,
+          duration: 3000
+        }
+      }));
     });
-    // window.dispatchEvent(evt); // to handle toast from window
-    this.dispatchEvent(evt); // to handle toast from tei-render
-
-    // console.log('yeah toast!',this.toast);
-    // if (
-    //   this.toast &&
-    //   this.toast.open
-    // )
-    //   this.toast.text = `${this.copyMessage}: ${this
-    //     .currentLineId}`;
-    //   this.toast.open();
   }
 
 

--- a/elements/tei-render/src/lib/css/drama.css
+++ b/elements/tei-render/src/lib/css/drama.css
@@ -782,14 +782,14 @@ tei-l[data-lineno]:before {
 tei-l:hover {
   background-color: #dedede;
 }
-tei-l paper-icon-button {
+tei-l simple-icon-button-lite {
   visibility: collapse;
   margin-top: -0.6em;
   /* right-side line link
   position: absolute;
   right: 9em; */
 }
-tei-l:hover paper-icon-button {
+tei-l:hover simple-icon-button-lite {
   /* Empty Rule Set */
   visibility: visible;
 } 
@@ -1213,10 +1213,8 @@ tei-pb {
   font-size: 11pt;
 }
 tei-pb {
-  --paper-icon-button: {
-    height: 50px;
-    width: 50px;
-}
+  --simple-icon-height: 36px;
+  --simple-icon-width: 36px;
 }
 /*
 tei-pb:before {

--- a/elements/tei-render/src/lib/tei-note.js
+++ b/elements/tei-render/src/lib/tei-note.js
@@ -1,6 +1,4 @@
 import { LitElement, html, css } from "lit-element/lit-element.js";
-import "@polymer/iron-icons/av-icons.js";
-//import "@polymer/paper-button/paper-button.js";
 import "@lrnwebcomponents/simple-popover/simple-popover.js";
 
 class TeiNote extends LitElement {

--- a/elements/tei-render/src/lib/tei-pb.js
+++ b/elements/tei-render/src/lib/tei-pb.js
@@ -1,6 +1,4 @@
 import { LitElement, html, css } from "lit-element/lit-element.js";
-import "@polymer/iron-icons/av-icons.js";
-import "@polymer/paper-icon-button/paper-icon-button.js";
 import "@lrnwebcomponents/simple-modal/lib/simple-modal-template.js";
 
 class TeiPB extends LitElement {
@@ -46,12 +44,12 @@ class TeiPB extends LitElement {
       super.firstUpdated();
     }
     setTimeout(() => {
-      this.shadowRoot.querySelector('simple-modal-template').associateEvents(this.shadowRoot.querySelector('paper-icon-button'));      
+      this.shadowRoot.querySelector('simple-modal-template').associateEvents(this.shadowRoot.querySelector('simple-icon-button-lite'));      
     }, 0);
   }
   render() {
     return html`
-    <paper-icon-button title="${this.title}" icon="${this.icon}"></paper-icon-button>!
+    <simple-icon-button-lite label="${this.title}" icon="${this.icon}"></simple-icon-button-lite>!
     <simple-modal-template title="${this.title}">
       <div slot="content"><slot></slot></div>
     </simple-modal-template>

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,11 @@
 # yarn lockfile v1
 
 
+"@a11y/focus-trap@^1.0.5":
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/@a11y/focus-trap/-/focus-trap-1.0.5.tgz#0748189c37ca21255c702aa5de3ee00ed4821d22"
+  integrity sha512-3JOd6g+BALysWS8LNf0qdB8ltR651H/RCLAvUmfS0LIHwHO579XfjZUIZbURYiAZrcbp1CBAq4QZ2YwKNQZ1hw==
+
 "@babel/code-frame@^7.0.0", "@babel/code-frame@^7.5.5", "@babel/code-frame@^7.8.3":
   version "7.8.3"
   resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.8.3.tgz#33e25903d7481181534e12ec0a25f16b6fcf419e"
@@ -1121,59 +1126,76 @@
     "@types/istanbul-reports" "^1.1.1"
     "@types/yargs" "^13.0.0"
 
-"@lrnwebcomponents/absolute-position-behavior@^2.6.17":
-  version "2.6.17"
-  resolved "https://registry.yarnpkg.com/@lrnwebcomponents/absolute-position-behavior/-/absolute-position-behavior-2.6.17.tgz#6066a24368fadfc81d061090fe21f60e07690011"
-  integrity sha512-8hlnzLGwPOZNWq0m0ZiO8HkdbLkqjj5ajfVVChVJmKSDZjIClwqCZdS7Ks0Go4rwtgVUQqJQjaSz1xOuzh36zA==
+"@lrnwebcomponents/absolute-position-behavior@^3.0.6":
+  version "3.0.6"
+  resolved "https://registry.yarnpkg.com/@lrnwebcomponents/absolute-position-behavior/-/absolute-position-behavior-3.0.6.tgz#94ffe8e21e2e0d9222425f9ec1c655d67856344f"
+  integrity sha512-dbu56Kqh8Vyl7SlmE7vEH81al94D2rY2r3aHE4D1XmWvgYtNCgz8VWVSPwrwlbIYT1hKmdQ1Vz5Usqxvoe3liA==
   dependencies:
-    "@polymer/iron-resizable-behavior" "^3.0.0"
-    lit-element "^2.3.1"
+    lit-element "2.4.0"
 
-"@lrnwebcomponents/anchor-behaviors@^2.6.16":
-  version "2.6.16"
-  resolved "https://registry.yarnpkg.com/@lrnwebcomponents/anchor-behaviors/-/anchor-behaviors-2.6.16.tgz#aa917f6caca31c24b609128f3ce10744cb4d4a3c"
-  integrity sha512-HgYy7agzVIXSeeTUDxbQ4eQbQUpZsahGMj3VdS364jXkQsbYjzYsyKLP6S8kQ9JEYsswJ1aeujdqBTdvtwMVcQ==
+"@lrnwebcomponents/anchor-behaviors@^3.0.5":
+  version "3.0.5"
+  resolved "https://registry.yarnpkg.com/@lrnwebcomponents/anchor-behaviors/-/anchor-behaviors-3.0.5.tgz#28b3f9d4431c1f58b27d91272283b575be3f1f68"
+  integrity sha512-SnKQM5mzgWKPHqjIze2c9n/SATuY3OuUaYDfiK8KmCWxean8xaUr+LIbCuPuMaW28JX0JvDdJKwfbyDE8YyUjA==
   dependencies:
     "@polymer/polymer" "^3.3.1"
 
-"@lrnwebcomponents/simple-modal@^2.6.18":
-  version "2.6.18"
-  resolved "https://registry.yarnpkg.com/@lrnwebcomponents/simple-modal/-/simple-modal-2.6.18.tgz#3bc00851816952a16bb7b494eecde5c97c4eeec7"
-  integrity sha512-jwqyeEeuAcKWD5nvF271Pru3BBdQ+3ii1iFiXOY0BQQqOjCQ57shentDfFaAGXzXb61WEmCcjJHs6JnAKvLp8A==
+"@lrnwebcomponents/simple-colors-shared-styles@^3.0.5":
+  version "3.0.5"
+  resolved "https://registry.yarnpkg.com/@lrnwebcomponents/simple-colors-shared-styles/-/simple-colors-shared-styles-3.0.5.tgz#e17f0f067e864e43e8cc7bf058daedbb060fe8b6"
+  integrity sha512-WJ5t/8SzTSxBPkmmWgOmD0wuS+nf0gccQH6PXeMlBv6MXU/+uGCih5dPMJg/iRRqOo13diRBfeCT0IvfJEQF7A==
   dependencies:
-    "@polymer/iron-icon" "^3.0.1"
-    "@polymer/iron-icons" "^3.0.1"
-    "@polymer/neon-animation" "^3.0.1"
-    "@polymer/paper-button" "^3.0.1"
-    "@polymer/paper-dialog" "^3.0.1"
-    "@polymer/paper-dialog-scrollable" "^3.0.1"
-    "@polymer/polymer" "^3.3.1"
-    web-animations-js "2.3.2"
+    lit-element "2.4.0"
 
-"@lrnwebcomponents/simple-popover@^2.6.17":
-  version "2.6.17"
-  resolved "https://registry.yarnpkg.com/@lrnwebcomponents/simple-popover/-/simple-popover-2.6.17.tgz#816de76f1011cc548b72c87065d5ad3b0706553f"
-  integrity sha512-VpFyXsOYnCiDr3xBccBqR2jB23H7suwCrEKfQKt+0TxxHycNgpu8mkuSR4S3enUcAPBmqen5rC2fjVT2dR8NoA==
+"@lrnwebcomponents/simple-colors@^3.0.6":
+  version "3.0.6"
+  resolved "https://registry.yarnpkg.com/@lrnwebcomponents/simple-colors/-/simple-colors-3.0.6.tgz#a783d71fb7223104c5e40736a745ffa192bfe0ed"
+  integrity sha512-1JRgYDa9RPFzDntZ82CWOLgnRYy6by+mDQbgTWbmvHYS38sGd2B7UyQ67fmUTdJMR+LL7uL/EZKQJVQmdISKrw==
   dependencies:
-    "@lrnwebcomponents/absolute-position-behavior" "^2.6.17"
-    "@polymer/polymer" "^3.3.1"
-    lit-element "^2.3.1"
+    "@lrnwebcomponents/simple-colors-shared-styles" "^3.0.5"
+    "@lrnwebcomponents/simple-picker" "^3.0.6"
+    lit-element "2.4.0"
 
-"@lrnwebcomponents/simple-toast@^2.6.17":
-  version "2.6.17"
-  resolved "https://registry.yarnpkg.com/@lrnwebcomponents/simple-toast/-/simple-toast-2.6.17.tgz#686119f0dc5dba1ec23868402b89425bc856eb28"
-  integrity sha512-WrHbLdUp2PY3pSKSiEap2s1aTUgO2fmKmVRyBFhmoRumzLWTxlPY5XHwtICPLRDKVA5CmQv5fWwIV1zhXMgAKA==
+"@lrnwebcomponents/simple-icon@^3.0.6":
+  version "3.0.6"
+  resolved "https://registry.yarnpkg.com/@lrnwebcomponents/simple-icon/-/simple-icon-3.0.6.tgz#aee42b9cf9a2b0798a4d369d0e00a9cbed81dc2a"
+  integrity sha512-sp+dbqtW0MmxHnlcvpAIcbj/rM2DR6z2Dvd3ur1s99XnX9mmli3b6gmUUyVhQOOR3qz5J1GG6nHxTEgwxByNIA==
   dependencies:
-    "@polymer/paper-button" "^3.0.1"
-    "@polymer/paper-toast" "^3.0.1"
-    lit-element "^2.3.1"
+    "@lrnwebcomponents/simple-colors" "^3.0.6"
+    lit-element "2.4.0"
 
-"@lrnwebcomponents/simple-tooltip@^2.6.17":
-  version "2.6.17"
-  resolved "https://registry.yarnpkg.com/@lrnwebcomponents/simple-tooltip/-/simple-tooltip-2.6.17.tgz#207458c74a10a675842e9460d96f98e2eba7a41e"
-  integrity sha512-bkHJQzBMkOVEcR8baiXfxxNunIaOm1shB2HDuIloyuV81P0MjjjhpPntvZvDRJg3MRNivFnH8EIV/l3ielAqpA==
+"@lrnwebcomponents/simple-modal@^3.0.6":
+  version "3.0.6"
+  resolved "https://registry.yarnpkg.com/@lrnwebcomponents/simple-modal/-/simple-modal-3.0.6.tgz#c6ffe76f553eaf77126206739583bc75e8cbcfff"
+  integrity sha512-xPcTW+VaMNGNQxR0q4CxygtPVAumcS346h2zM7r//Kvy5ErFlXfQDyTajmN5li+14asPXMNXzGYJOTcvupCEyA==
   dependencies:
-    lit-element "^2.3.1"
+    "@lrnwebcomponents/simple-icon" "^3.0.6"
+    lit-element "2.4.0"
+    web-dialog "0.0.11"
+
+"@lrnwebcomponents/simple-picker@^3.0.6":
+  version "3.0.6"
+  resolved "https://registry.yarnpkg.com/@lrnwebcomponents/simple-picker/-/simple-picker-3.0.6.tgz#fde5340ed066949376be87115198979250593ce3"
+  integrity sha512-a5dvc8AC6hrbKTjG4WdgnSWSolvWYgb5ZkOTACpoLndHViSWkopK5W/pi6cyWKvCcQXDvz/dNQkwE6xvKus6qQ==
+  dependencies:
+    "@lrnwebcomponents/simple-icon" "^3.0.6"
+    lit-element "2.4.0"
+
+"@lrnwebcomponents/simple-popover@^3.0.6":
+  version "3.0.6"
+  resolved "https://registry.yarnpkg.com/@lrnwebcomponents/simple-popover/-/simple-popover-3.0.6.tgz#86c424ae68e3a6cf1737b03be1b5038c4ee8feeb"
+  integrity sha512-naCs0i7OYgwpNhzRLbMEb4LMKL2W8ugQ4/nXXIbu3ms2LwibyQvBimVW6GWz1YXtlOffKZHTIt3J+yWL8KpBeA==
+  dependencies:
+    "@lrnwebcomponents/absolute-position-behavior" "^3.0.6"
+    lit-element "2.4.0"
+
+"@lrnwebcomponents/simple-toast@^3.0.6":
+  version "3.0.6"
+  resolved "https://registry.yarnpkg.com/@lrnwebcomponents/simple-toast/-/simple-toast-3.0.6.tgz#5cef97e13945bac7a6cada8b058d5c03a94fa9de"
+  integrity sha512-euckYhZM4+60Hb6fdlcDP0NyKlbFbQhjOQUrtSsAdvQ/ZiJII5KTPiaz9OSibcyXM3A1nWHVwz/9L+pSpNcQBg==
+  dependencies:
+    "@lrnwebcomponents/simple-colors" "^3.0.6"
+    lit-element "2.4.0"
 
 "@mdjs/core@^0.1.6":
   version "0.1.6"
@@ -1435,224 +1457,7 @@
     mocha "^6.2.2"
     sinon-chai "^3.3.0"
 
-"@polymer/font-roboto@^3.0.1":
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/@polymer/font-roboto/-/font-roboto-3.0.2.tgz#80cdaa7225db2359130dfb2c6d9a3be1820020c3"
-  integrity sha512-tx5TauYSmzsIvmSqepUPDYbs4/Ejz2XbZ1IkD7JEGqkdNUJlh+9KU85G56Tfdk/xjEZ8zorFfN09OSwiMrIQWA==
-
-"@polymer/iron-a11y-announcer@^3.0.0-pre.26":
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/@polymer/iron-a11y-announcer/-/iron-a11y-announcer-3.0.2.tgz#730dd36ccb2e042ecd5160ba439c2bf2f8a97412"
-  integrity sha512-LqnMF39mXyxSSRbTHRzGbcJS8nU0NVTo2raBOgOlpxw5yfGJUVcwaTJ/qy5NtWCZLRfa4suycf0oAkuUjHTXHQ==
-  dependencies:
-    "@polymer/polymer" "^3.0.0"
-
-"@polymer/iron-a11y-keys-behavior@^3.0.0-pre.26":
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/@polymer/iron-a11y-keys-behavior/-/iron-a11y-keys-behavior-3.0.1.tgz#2868ea72912d2007ffab4734684a91f5aac49b84"
-  integrity sha512-lnrjKq3ysbBPT/74l0Fj0U9H9C35Tpw2C/tpJ8a+5g8Y3YJs1WSZYnEl1yOkw6sEyaxOq/1DkzH0+60gGu5/PQ==
-  dependencies:
-    "@polymer/polymer" "^3.0.0"
-
-"@polymer/iron-behaviors@^3.0.0-pre.26":
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/@polymer/iron-behaviors/-/iron-behaviors-3.0.1.tgz#a3b6f876779a7f0a91a15e4423890968b6525901"
-  integrity sha512-IMEwcv1lhf1HSQxuyWOUIL0lOBwmeaoSTpgCJeP9IBYnuB1SPQngmfRuHKgK6/m9LQ9F9miC7p3HeQQUdKAE0w==
-  dependencies:
-    "@polymer/iron-a11y-keys-behavior" "^3.0.0-pre.26"
-    "@polymer/polymer" "^3.0.0"
-
-"@polymer/iron-checked-element-behavior@^3.0.0-pre.26":
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/@polymer/iron-checked-element-behavior/-/iron-checked-element-behavior-3.0.1.tgz#7a4b49646603657ab2c5e5ca7bd97f34444fdaf5"
-  integrity sha512-aDr0cbCNVq49q+pOqa6CZutFh+wWpwPMLpEth9swx+GkAj+gCURhuQkaUYhIo5f2egDbEioR1aeHMnPlU9dQZA==
-  dependencies:
-    "@polymer/iron-form-element-behavior" "^3.0.0-pre.26"
-    "@polymer/iron-validatable-behavior" "^3.0.0-pre.26"
-    "@polymer/polymer" "^3.0.0"
-
-"@polymer/iron-fit-behavior@^3.0.0-pre.26":
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/@polymer/iron-fit-behavior/-/iron-fit-behavior-3.0.2.tgz#2ec460d8a6b0151394b55631a72a68b92e14e2e0"
-  integrity sha512-JndryJYbBR3gSN5IlST4rCHsd01+OyvYpRO6z5Zd3C6u5V/m07TwAtcf3aXwZ8WBNt2eLG28OcvdSO7XR2v2pg==
-  dependencies:
-    "@polymer/polymer" "^3.0.0"
-
-"@polymer/iron-flex-layout@^3.0.0-pre.26":
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/@polymer/iron-flex-layout/-/iron-flex-layout-3.0.1.tgz#36f9e1a8eb792d279b2bc75d362628721ad37f0c"
-  integrity sha512-7gB869czArF+HZcPTVSgvA7tXYFze9EKckvM95NB7SqYF+NnsQyhoXgKnpFwGyo95lUjUW9TFDLUwDXnCYFtkw==
-  dependencies:
-    "@polymer/polymer" "^3.0.0"
-
-"@polymer/iron-form-element-behavior@^3.0.0-pre.26":
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/@polymer/iron-form-element-behavior/-/iron-form-element-behavior-3.0.1.tgz#4c79e1981d7796ce659e997f3b8f5e14b4a075a4"
-  integrity sha512-G/e2KXyL5AY7mMjmomHkGpgS0uAf4ovNpKhkuUTRnMuMJuf589bKqE85KN4ovE1Tzhv2hJoh/igyD6ekHiYU1A==
-  dependencies:
-    "@polymer/polymer" "^3.0.0"
-
-"@polymer/iron-icon@^3.0.0-pre.26", "@polymer/iron-icon@^3.0.1":
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/@polymer/iron-icon/-/iron-icon-3.0.1.tgz#93211c39d8825fe4965a68419566036c1df291eb"
-  integrity sha512-QLPwirk+UPZNaLnMew9VludXA4CWUCenRewgEcGYwdzVgDPCDbXxy6vRJjmweZobMQv/oVLppT2JZtJFnPxX6g==
-  dependencies:
-    "@polymer/iron-flex-layout" "^3.0.0-pre.26"
-    "@polymer/iron-meta" "^3.0.0-pre.26"
-    "@polymer/polymer" "^3.0.0"
-
-"@polymer/iron-icons@^3.0.1":
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/@polymer/iron-icons/-/iron-icons-3.0.1.tgz#c1bd31d8483afbdb5422cdc384081e19c9267cfe"
-  integrity sha512-xtEI8erH2GIBiF3QxEMyW81XuVjguu6Le5WjEEpX67qd9z7jjmc4T/ke3zRUlnDydex9p8ytcwVpMIKcyvjYAQ==
-  dependencies:
-    "@polymer/iron-icon" "^3.0.0-pre.26"
-    "@polymer/iron-iconset-svg" "^3.0.0-pre.26"
-    "@polymer/polymer" "^3.0.0"
-
-"@polymer/iron-iconset-svg@^3.0.0-pre.26":
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/@polymer/iron-iconset-svg/-/iron-iconset-svg-3.0.1.tgz#568d6e7dbc120299dae63be3600aeba0d30ddbea"
-  integrity sha512-XNwURbNHRw6u2fJe05O5fMYye6GSgDlDqCO+q6K1zAnKIrpgZwf2vTkBd5uCcZwsN0FyCB3mvNZx4jkh85dRDw==
-  dependencies:
-    "@polymer/iron-meta" "^3.0.0-pre.26"
-    "@polymer/polymer" "^3.0.0"
-
-"@polymer/iron-meta@^3.0.0-pre.26":
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/@polymer/iron-meta/-/iron-meta-3.0.1.tgz#7f140628d127b0a284f882f1bb323a261bc125f5"
-  integrity sha512-pWguPugiLYmWFV9UWxLWzZ6gm4wBwQdDy4VULKwdHCqR7OP7u98h+XDdGZsSlDPv6qoryV/e3tGHlTIT0mbzJA==
-  dependencies:
-    "@polymer/polymer" "^3.0.0"
-
-"@polymer/iron-overlay-behavior@^3.0.0-pre.27":
-  version "3.0.3"
-  resolved "https://registry.yarnpkg.com/@polymer/iron-overlay-behavior/-/iron-overlay-behavior-3.0.3.tgz#29c198e19e05bb2bcf7d86d3c11848cb93301d00"
-  integrity sha512-Q/Fp0+uOQQ145ebZ7T8Cxl4m1tUKYjyymkjcL2rXUm+aDQGb1wA1M1LYxUF5YBqd+9lipE0PTIiYwA2ZL/sznA==
-  dependencies:
-    "@polymer/iron-a11y-keys-behavior" "^3.0.0-pre.26"
-    "@polymer/iron-fit-behavior" "^3.0.0-pre.26"
-    "@polymer/iron-resizable-behavior" "^3.0.0-pre.26"
-    "@polymer/polymer" "^3.0.0"
-
-"@polymer/iron-resizable-behavior@^3.0.0", "@polymer/iron-resizable-behavior@^3.0.0-pre.26":
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/@polymer/iron-resizable-behavior/-/iron-resizable-behavior-3.0.1.tgz#e284348ed7c1c7e263f7039297532fa954025ea2"
-  integrity sha512-FyHxRxFspVoRaeZSWpT3y0C9awomb4tXXolIJcZ7RvXhMP632V5lez+ch5G5SwK0LpnAPkg35eB0LPMFv+YMMQ==
-  dependencies:
-    "@polymer/polymer" "^3.0.0"
-
-"@polymer/iron-selector@^3.0.0-pre.26":
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/@polymer/iron-selector/-/iron-selector-3.0.1.tgz#e845bec58489c96b4e7609525532437869ad5a88"
-  integrity sha512-sBVk2uas6prW0glUe2xEJJYlvxmYzM40Au9OKbfDK2Qekou/fLKcBRyIYI39kuI8zWRaip8f3CI8qXcUHnKb1A==
-  dependencies:
-    "@polymer/polymer" "^3.0.0"
-
-"@polymer/iron-validatable-behavior@^3.0.0-pre.26":
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/@polymer/iron-validatable-behavior/-/iron-validatable-behavior-3.0.1.tgz#73538f005a07741c31b6fc1e981168c3d3e0d92b"
-  integrity sha512-wwpYh6wOa4fNI+jH5EYKC7TVPYQ2OfgQqocWat7GsNWcsblKYhLYbwsvEY5nO0n2xKqNfZzDLrUom5INJN7msQ==
-  dependencies:
-    "@polymer/iron-meta" "^3.0.0-pre.26"
-    "@polymer/polymer" "^3.0.0"
-
-"@polymer/neon-animation@^3.0.0-pre.26", "@polymer/neon-animation@^3.0.1":
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/@polymer/neon-animation/-/neon-animation-3.0.1.tgz#6658e4b524abc057477772a7473292493d366c24"
-  integrity sha512-cDDc0llpVCe0ATbDS3clDthI54Bc8YwZIeTGGmBJleKOvbRTUC5+ssJmRL+VwVh+VM5FlnQlx760ppftY3uprg==
-  dependencies:
-    "@polymer/iron-resizable-behavior" "^3.0.0-pre.26"
-    "@polymer/iron-selector" "^3.0.0-pre.26"
-    "@polymer/polymer" "^3.0.0"
-
-"@polymer/paper-behaviors@^3.0.0-pre.27":
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/@polymer/paper-behaviors/-/paper-behaviors-3.0.1.tgz#83f1cd06489f484c1b108a2967fb01952df722ad"
-  integrity sha512-6knhj69fPJejv8qR0kCSUY+Q0XjaUf0OSnkjRjmTJPAwSrRYtgqE+l6P1FfA+py1X/cUjgne9EF5rMZAKJIg1g==
-  dependencies:
-    "@polymer/iron-behaviors" "^3.0.0-pre.26"
-    "@polymer/iron-checked-element-behavior" "^3.0.0-pre.26"
-    "@polymer/paper-ripple" "^3.0.0-pre.26"
-    "@polymer/polymer" "^3.0.0"
-
-"@polymer/paper-button@^3.0.1":
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/@polymer/paper-button/-/paper-button-3.0.1.tgz#f13b019137e3f6ccc4d04d0b1f27f4830ea5774d"
-  integrity sha512-JRNBc+Oj9EWnmyLr7FcCr8T1KAnEHPh6mosln9BUdkM+qYaYsudSICh3cjTIbnj6AuF5OJidoLkM1dlyj0j6Zg==
-  dependencies:
-    "@polymer/iron-flex-layout" "^3.0.0-pre.26"
-    "@polymer/paper-behaviors" "^3.0.0-pre.27"
-    "@polymer/paper-styles" "^3.0.0-pre.26"
-    "@polymer/polymer" "^3.0.0"
-
-"@polymer/paper-dialog-behavior@^3.0.0-pre.26":
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/@polymer/paper-dialog-behavior/-/paper-dialog-behavior-3.0.1.tgz#819b2fbb9444c1c318ddf55f02819bb29a85657b"
-  integrity sha512-wbI4kCK8le/9MHT+IXzvHjoatxf3kd3Yn0tgozAiAwfSZ7N4Ubpi5MHrK0m9S9PeIxKokAgBYdTUrezSE5378A==
-  dependencies:
-    "@polymer/iron-overlay-behavior" "^3.0.0-pre.27"
-    "@polymer/paper-styles" "^3.0.0-pre.26"
-    "@polymer/polymer" "^3.0.0"
-
-"@polymer/paper-dialog-scrollable@^3.0.1":
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/@polymer/paper-dialog-scrollable/-/paper-dialog-scrollable-3.0.1.tgz#42fd30380320e6dd6d4d68b2ac4e45ee9e5e024f"
-  integrity sha512-1E8B9kNdL58jUrJ/BwqJeOoNVcxNrB559z//d1V0rVHWT5bWCCZegwS3G06iFK5MjxWFbIKzleVTLrT0opiZkA==
-  dependencies:
-    "@polymer/iron-flex-layout" "^3.0.0-pre.26"
-    "@polymer/paper-dialog-behavior" "^3.0.0-pre.26"
-    "@polymer/paper-styles" "^3.0.0-pre.26"
-    "@polymer/polymer" "^3.0.0"
-
-"@polymer/paper-dialog@^3.0.1":
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/@polymer/paper-dialog/-/paper-dialog-3.0.1.tgz#728ebdbfc4d35ec1485e543434cef5dba476f15e"
-  integrity sha512-KvglYbEq7AWJvui2j6WKLnOvgVMeGjovAydGrPRj7kVzCiD49Eq/hpYFJTRV5iDcalWH+mORUpw+jrFnG9+Kgw==
-  dependencies:
-    "@polymer/iron-overlay-behavior" "^3.0.0-pre.27"
-    "@polymer/neon-animation" "^3.0.0-pre.26"
-    "@polymer/paper-dialog-behavior" "^3.0.0-pre.26"
-    "@polymer/polymer" "^3.0.0"
-
-"@polymer/paper-icon-button@^3.0.2":
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/@polymer/paper-icon-button/-/paper-icon-button-3.0.2.tgz#a1254faadc2c8dd135ce1ae33bcc161a94c31f65"
-  integrity sha512-kOdxQgnKL097bggFF6PWvsBYuWg+MCcoHoTHX6bh/MuZoWFZNjrFntFqwuB4oEbpjCpfm4moA33muPJFj7CihQ==
-  dependencies:
-    "@polymer/iron-icon" "^3.0.0-pre.26"
-    "@polymer/paper-behaviors" "^3.0.0-pre.27"
-    "@polymer/paper-styles" "^3.0.0-pre.26"
-    "@polymer/polymer" "^3.0.0"
-
-"@polymer/paper-ripple@^3.0.0-pre.26":
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/@polymer/paper-ripple/-/paper-ripple-3.0.2.tgz#52566f5ee367942022ceaa991368105d21403de5"
-  integrity sha512-DnLNvYIMsiayeICroYxx6Q6Hg1cUU8HN2sbutXazlemAlGqdq80qz3TIaVdbpbt/pvjcFGX2HtntMlPstCge8Q==
-  dependencies:
-    "@polymer/iron-a11y-keys-behavior" "^3.0.0-pre.26"
-    "@polymer/polymer" "^3.0.0"
-
-"@polymer/paper-styles@^3.0.0-pre.26":
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/@polymer/paper-styles/-/paper-styles-3.0.1.tgz#bd4962b83ab8432cd1cf197bb5222d3a08f135e1"
-  integrity sha512-y6hmObLqlCx602TQiSBKHqjwkE7xmDiFkoxdYGaNjtv4xcysOTdVJsDR/R9UHwIaxJ7gHlthMSykir1nv78++g==
-  dependencies:
-    "@polymer/font-roboto" "^3.0.1"
-    "@polymer/iron-flex-layout" "^3.0.0-pre.26"
-    "@polymer/polymer" "^3.0.0"
-
-"@polymer/paper-toast@^3.0.1":
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/@polymer/paper-toast/-/paper-toast-3.0.1.tgz#213aa3373909cee7c8e17299cf70fa2603bfb358"
-  integrity sha512-pizuogzObniDdICUc6dSLrnDt2VzzoRne1gCmbD6sfOATVv5tc8UfrqhA2iHngbNBEbniBiciS3iogdp5KTVUQ==
-  dependencies:
-    "@polymer/iron-a11y-announcer" "^3.0.0-pre.26"
-    "@polymer/iron-fit-behavior" "^3.0.0-pre.26"
-    "@polymer/iron-overlay-behavior" "^3.0.0-pre.27"
-    "@polymer/polymer" "^3.0.0"
-
-"@polymer/polymer@^3.0.0", "@polymer/polymer@^3.3.1":
+"@polymer/polymer@^3.3.1":
   version "3.3.1"
   resolved "https://registry.yarnpkg.com/@polymer/polymer/-/polymer-3.3.1.tgz#9ad48992d2a96775f80b0673f3a615d6df8a3dfc"
   integrity sha512-8KaB48tzyMjdsHdxo5KvCAaqmTe7rYDzQAoj/pyEfq9Fp4YfUaS+/xqwYj0GbiDAUNzwkmEQ7dw9cgnRNdKO8A==
@@ -6136,14 +5941,28 @@ listr@^0.14.2:
     p-map "^2.0.0"
     rxjs "^6.3.3"
 
-lit-element@^2.2.1, lit-element@^2.3.1:
+lit-element@2.4.0:
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/lit-element/-/lit-element-2.4.0.tgz#b22607a037a8fc08f5a80736dddf7f3f5d401452"
+  integrity sha512-pBGLglxyhq/Prk2H91nA0KByq/hx/wssJBQFiYqXhGDvEnY31PRGYf1RglVzyLeRysu0IHm2K0P196uLLWmwFg==
+  dependencies:
+    lit-html "^1.1.1"
+
+lit-element@2.5.1:
+  version "2.5.1"
+  resolved "https://registry.yarnpkg.com/lit-element/-/lit-element-2.5.1.tgz#3fa74b121a6cd22902409ae3859b7847d01aa6b6"
+  integrity sha512-ogu7PiJTA33bEK0xGu1dmaX5vhcRjBXCFexPja0e7P7jqLhTpNKYRPmE+GmiCaRVAbiQKGkUgkh/i6+bh++dPQ==
+  dependencies:
+    lit-html "^1.1.1"
+
+lit-element@^2.2.1:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/lit-element/-/lit-element-2.3.1.tgz#73343b978fa1e73d60526c6bb6ad60f53a16c343"
   integrity sha512-tOcUAmeO3BzwiQ7FGWdsshNvC0HVHcTFYw/TLIImmKwXYoV0E7zCBASa8IJ7DiP4cen/Yoj454gS0qqTnIGsFA==
   dependencies:
     lit-html "^1.1.1"
 
-lit-html@^1.0.0, lit-html@^1.1.1, lit-html@^1.2.1:
+lit-html@^1.0.0, lit-html@^1.1.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/lit-html/-/lit-html-1.2.1.tgz#1fb933dc1e2ddc095f60b8086277d4fcd9d62cc8"
   integrity sha512-GSJHHXMGLZDzTRq59IUfL9FCdAlGfqNp/dEa7k7aBaaWD+JKaCjsAk9KYm2V12ItonVaYx2dprN66Zdm1AuBTQ==
@@ -9647,10 +9466,12 @@ warning@^4.0.2, warning@^4.0.3:
   dependencies:
     loose-envify "^1.0.0"
 
-web-animations-js@2.3.2:
-  version "2.3.2"
-  resolved "https://registry.yarnpkg.com/web-animations-js/-/web-animations-js-2.3.2.tgz#a51963a359c543f97b47c7d4bc2d811f9fc9e153"
-  integrity sha512-TOMFWtQdxzjWp8qx4DAraTWTsdhxVSiWa6NkPFSaPtZ1diKUxTn4yTix73A1euG1WbSOMMPcY51cnjTIHrGtDA==
+web-dialog@0.0.11:
+  version "0.0.11"
+  resolved "https://registry.yarnpkg.com/web-dialog/-/web-dialog-0.0.11.tgz#0cd9b25c560fdad01bb84b6754ee5d1ba5fe9562"
+  integrity sha512-UGXpUfww+U2zWJCwb8uE0zeiCjyq4gv54VpC2zuT4+sOdR/ukz7flp941472BY9TnI8RrK3S5TLL4K9AQycfwQ==
+  dependencies:
+    "@a11y/focus-trap" "^1.0.5"
 
 web-namespaces@^1.0.0, web-namespaces@^1.1.2:
   version "1.1.4"


### PR DESCRIPTION
This updates the lrnwebcomponents code bases to be the latest published releases. Also removes polymer based elements and replaces with our `simple-` versions. Should load faster with less code but test to ensure it didn't break anything. At a glance all functionality seemed the same to me.