### PR TITLE
tei-render: Tighten up alignment of line numbers so they are not obscured by other page elements

### DIFF
--- a/elements/tei-render/src/lib/css/drama.css
+++ b/elements/tei-render/src/lib/css/drama.css
@@ -777,7 +777,7 @@ tei-l {
 tei-l[data-lineno]:before {
   content: attr(data-lineno);
   position: absolute;
-  right: 6em;
+  right: -10em;
 }
 tei-l:hover {
   background-color: #dedede;
@@ -1808,6 +1808,7 @@ tei-border: 1px solid black;
 tei-background:white;
 tei-*/
   line-height: 1.5;
+  position: relative;
 }
 tei-textClass {
   display: none;


### PR DESCRIPTION
Fixes https://servicedesk.css.psu.edu/browse/APPINT-4826

<img width="1438" alt="Screen Shot 2021-06-03 at 1 20 29 PM" src="https://user-images.githubusercontent.com/639920/120688657-4a30e900-c471-11eb-82e8-891eebd4d99f.png">
