### PR TITLE
Only show square brackets for <tei-stage> if it has a resp attribute

### DIFF
--- a/elements/tei-render/src/lib/css/drama.css
+++ b/elements/tei-render/src/lib/css/drama.css
@@ -1660,11 +1660,11 @@ tei-stage:not([place]){
   display: inline-block;
   margin-right:0px;
 }
-tei-stage:before {
-  content: "[ "
+tei-stage[resp]:before {
+  content: "[ ";
 }
-tei-stage:after {
-  content: " ]"
+tei-stage[resp]:after {
+  content: " ]";
 }
 tei-stage[place=center] {
   display: inline-block;


### PR DESCRIPTION
Fixes: https://servicedesk.css.psu.edu/browse/APPINT-4854

### Before:
<img width="939" alt="Screen Shot 2021-07-01 at 10 26 41 AM" src="https://user-images.githubusercontent.com/639920/124163335-8144eb00-da6d-11eb-99ee-d09f1e0ab9f8.png">

### After:
<img width="974" alt="Screen Shot 2021-07-01 at 10 26 49 AM" src="https://user-images.githubusercontent.com/639920/124163344-85710880-da6d-11eb-8297-069ec840e7f3.png">
