### PR TITLE
UI/UX improvements to <tei-note>

### DIFF
--- a/elements/tei-render/src/lib/tei-note.js
+++ b/elements/tei-render/src/lib/tei-note.js
@@ -7,9 +7,21 @@ class TeiNote extends LitElement {
       :host {
         display: inline-flex;
       }
+      a {
+        text-indent: 0;
+      }
       simple-popover {
         max-width: 50vw;
-        padding: 16px;
+      }
+      simple-popover a {
+        display: block;
+        width: 16px;
+        margin-left: auto;
+        margin-right: 0;
+      }
+      iron-icon {
+        height: 16px;
+        width: 16px;
       }
     `];
   }
@@ -46,8 +58,13 @@ class TeiNote extends LitElement {
   }
   render() {
     return html`
-    <a href="javascript:void(0);" title="${this.title}" icon="${this.icon}" @click="${this.toggleStatus}">@</a>
+    <a href="javascript:void(0);" title="${this.title}" icon="${this.icon}" @click="${this.toggleStatus}">
+      <iron-icon icon="info-outline"></iron-icon>
+    </a>
     <simple-popover auto ?hidden="${this.hiddenStatus}">
+      <a href="javascript:void(0);" title="Close Popover" @click="${this.toggleStatus}">
+        <iron-icon icon="close"></iron-icon>
+      </a>
       <slot></slot>
     </simple-popover>
     `;


### PR DESCRIPTION
Fixes https://servicedesk.css.psu.edu/browse/APPINT-4829
Fixes https://servicedesk.css.psu.edu/browse/APPINT-4832

- use an info icon instead of @ to indicate a note
- fix padding so popover appears directly below the info icon
- add a close button in the popover to make it easier to close

### Before
<img width="612" alt="Screen Shot 2021-07-02 at 3 17 21 PM" src="https://user-images.githubusercontent.com/639920/124319900-ec172480-db48-11eb-8505-7c17bcd4ecd3.png">

### After
<img width="677" alt="Screen Shot 2021-07-02 at 3 09 12 PM" src="https://user-images.githubusercontent.com/639920/124319917-f0dbd880-db48-11eb-89d4-340c07bbc0cc.png">
